### PR TITLE
* Complete IO refactorization

### DIFF
--- a/Wazzy.sln
+++ b/Wazzy.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30621.155
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wazzy", "Wazzy\Wazzy.csproj", "{009A285D-BBE1-4CAB-B277-C5CEBED757D2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Wazzy", "Wazzy\Wazzy.csproj", "{009A285D-BBE1-4CAB-B277-C5CEBED757D2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wazzy.CLI", "Wazzy.CLI\Wazzy.CLI.csproj", "{5A46906F-18EE-4B96-A528-7A7ADDA1E38B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Wazzy.CLI", "Wazzy.CLI\Wazzy.CLI.csproj", "{5A46906F-18EE-4B96-A528-7A7ADDA1E38B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Wazzy/Bytecode/Instructions/Control/BlockIns.cs
+++ b/Wazzy/Bytecode/Instructions/Control/BlockIns.cs
@@ -17,10 +17,10 @@ namespace Wazzy.Bytecode.Instructions.Control
         {
             Expression = new List<WASMInstruction>();
         }
-        public BlockIns(WASMReader input)
+        public BlockIns(ref WASMReader input)
             : base(OPCode.Block)
         {
-            BlockId = input.Read7BitEncodedInt();
+            BlockId = input.ReadIntLEB128();
             if (WASMType.IsSupportedType(BlockId))
             {
                 BlockType = WASMType.GetType(BlockId);
@@ -29,13 +29,24 @@ namespace Wazzy.Bytecode.Instructions.Control
             Expression = input.ReadExpression();
         }
 
-        protected override void WriteBodyTo(WASMWriter output)
+        protected override void WriteBodyTo(ref WASMWriter output)
         {
-            output.Write7BitEncodedInt(BlockId);
+            output.WriteLEB128(BlockId);
             foreach (WASMInstruction instruction in Expression)
             {
-                instruction.WriteTo(output);
+                instruction.WriteTo(ref output);
             }
+        }
+
+        protected override int GetBodySize()
+        {
+            int size = 0;
+            size += WASMReader.GetLEB128Size(BlockId);
+            foreach (var instruction in Expression)
+            {
+                size += instruction.GetSize();
+            }
+            return size;
         }
     }
 }

--- a/Wazzy/Bytecode/Instructions/Control/BranchIfIns.cs
+++ b/Wazzy/Bytecode/Instructions/Control/BranchIfIns.cs
@@ -6,8 +6,8 @@ namespace Wazzy.Bytecode.Instructions.Control
     {
         public int LabelIndex { get; set; }
 
-        public BranchIfIns(WASMReader input)
-            : this(input.Read7BitEncodedInt())
+        public BranchIfIns(ref WASMReader input)
+            : this(input.ReadIntLEB128())
         { }
         public BranchIfIns(int labelIndex = 0)
             : base(OPCode.BranchIf)
@@ -15,9 +15,11 @@ namespace Wazzy.Bytecode.Instructions.Control
             LabelIndex = labelIndex;
         }
 
-        protected override void WriteBodyTo(WASMWriter output)
+        protected override void WriteBodyTo(ref WASMWriter output)
         {
-            output.Write7BitEncodedInt(LabelIndex);
+            output.WriteLEB128(LabelIndex);
         }
+
+        protected override int GetBodySize() => WASMReader.GetLEB128Size(LabelIndex);
     }
 }

--- a/Wazzy/Bytecode/Instructions/Control/BranchIns.cs
+++ b/Wazzy/Bytecode/Instructions/Control/BranchIns.cs
@@ -6,8 +6,8 @@ namespace Wazzy.Bytecode.Instructions.Control
     {
         public int LabelIndex { get; set; }
 
-        public BranchIns(WASMReader input)
-            : this(input.Read7BitEncodedInt())
+        public BranchIns(ref WASMReader input)
+            : this(input.ReadIntLEB128())
         { }
         public BranchIns(int labelIndex = 0)
             : base(OPCode.Branch)
@@ -15,9 +15,11 @@ namespace Wazzy.Bytecode.Instructions.Control
             LabelIndex = labelIndex;
         }
 
-        protected override void WriteBodyTo(WASMWriter output)
+        protected override void WriteBodyTo(ref WASMWriter output)
         {
-            output.Write7BitEncodedInt(LabelIndex);
+            output.WriteLEB128(LabelIndex);
         }
+
+        protected override int GetBodySize() => WASMReader.GetLEB128Size(LabelIndex);
     }
 }

--- a/Wazzy/Bytecode/Instructions/Control/BranchTableIns.cs
+++ b/Wazzy/Bytecode/Instructions/Control/BranchTableIns.cs
@@ -14,25 +14,37 @@ namespace Wazzy.Bytecode.Instructions.Control
         {
             LabelIndices = new List<int>();
         }
-        public BranchTableIns(WASMReader input)
+        public BranchTableIns(ref WASMReader input)
             : this()
         {
-            LabelIndices.Capacity = input.Read7BitEncodedInt();
+            LabelIndices.Capacity = input.ReadIntLEB128();
             for (int i = 0; i < LabelIndices.Capacity; i++)
             {
-                LabelIndices.Add(input.Read7BitEncodedInt());
+                LabelIndices.Add(input.ReadIntLEB128());
             }
-            LabelIndex = input.Read7BitEncodedInt();
+            LabelIndex = input.ReadIntLEB128();
         }
 
-        protected override void WriteBodyTo(WASMWriter output)
+        protected override void WriteBodyTo(ref WASMWriter output)
         {
-            output.Write7BitEncodedInt(LabelIndices.Count);
+            output.WriteLEB128(LabelIndices.Count);
             foreach (int labelIndex in LabelIndices)
             {
-                output.Write7BitEncodedInt(labelIndex);
+                output.WriteLEB128(labelIndex);
             }
-            output.Write7BitEncodedInt(LabelIndex);
+            output.WriteLEB128(LabelIndex);
+        }
+
+        protected override int GetBodySize()
+        {
+            int size = 0;
+            size += WASMReader.GetLEB128Size(LabelIndices.Count);
+            foreach (int labelIndex in LabelIndices)
+            {
+                size += WASMReader.GetLEB128Size(labelIndex);
+            }
+            size += WASMReader.GetLEB128Size(LabelIndex);
+            return size;
         }
     }
 }

--- a/Wazzy/Bytecode/Instructions/Control/CallIndirectIns.cs
+++ b/Wazzy/Bytecode/Instructions/Control/CallIndirectIns.cs
@@ -11,11 +11,19 @@ namespace Wazzy.Bytecode.Instructions.Control
         {
             TypeIndex = typeIndex;
         }
-        public CallIndirectIns(WASMReader input)
-            : this(input.Read7BitEncodedInt())
+        public CallIndirectIns(ref WASMReader input)
+            : this(input.ReadIntLEB128())
         {
             /* In future versions of WebAssembly, the zero byte occurring in the encoding of the call_indirect instruction may be used to index additional tables. */
             input.ReadByte();
         }
+
+        protected override void WriteBodyTo(ref WASMWriter output)
+        {
+            output.WriteLEB128(TypeIndex);
+            output.Write((byte)0);
+        }
+
+        protected override int GetBodySize() => WASMReader.GetLEB128Size(TypeIndex) + sizeof(byte);
     }
 }

--- a/Wazzy/Bytecode/Instructions/Control/CallIns.cs
+++ b/Wazzy/Bytecode/Instructions/Control/CallIns.cs
@@ -6,8 +6,8 @@ namespace Wazzy.Bytecode.Instructions.Control
     {
         public int FunctionIndex { get; set; }
 
-        public CallIns(WASMReader input)
-            : this(input.Read7BitEncodedInt())
+        public CallIns(ref WASMReader input)
+            : this(input.ReadIntLEB128())
         { }
         public CallIns(int functionIndex = 0)
             : base(OPCode.Call)
@@ -15,9 +15,11 @@ namespace Wazzy.Bytecode.Instructions.Control
             FunctionIndex = functionIndex;
         }
 
-        protected override void WriteBodyTo(WASMWriter output)
+        protected override void WriteBodyTo(ref WASMWriter output)
         {
-            output.Write7BitEncodedInt(FunctionIndex);
+            output.WriteLEB128(FunctionIndex);
         }
+
+        protected override int GetBodySize() => WASMReader.GetLEB128Size(FunctionIndex);
     }
 }

--- a/Wazzy/Bytecode/Instructions/Control/LoopIns.cs
+++ b/Wazzy/Bytecode/Instructions/Control/LoopIns.cs
@@ -17,10 +17,10 @@ namespace Wazzy.Bytecode.Instructions.Control
         {
             Expression = new List<WASMInstruction>();
         }
-        public LoopIns(WASMReader input)
+        public LoopIns(ref WASMReader input)
             : base(OPCode.Loop)
         {
-            BlockId = input.Read7BitEncodedInt();
+            BlockId = input.ReadIntLEB128();
             if (WASMType.IsSupportedType(BlockId))
             {
                 BlockType = WASMType.GetType(BlockId);
@@ -29,13 +29,23 @@ namespace Wazzy.Bytecode.Instructions.Control
             Expression = input.ReadExpression();
         }
 
-        protected override void WriteBodyTo(WASMWriter output)
+        protected override void WriteBodyTo(ref WASMWriter output)
         {
-            output.Write7BitEncodedInt(BlockId);
+            output.WriteLEB128(BlockId);
             foreach (WASMInstruction instruction in Expression)
             {
-                instruction.WriteTo(output);
+                instruction.WriteTo(ref output);
             }
+        }
+        protected override int GetBodySize()
+        {
+            int size = 0;
+            size += WASMReader.GetLEB128Size(BlockId);
+            foreach (WASMInstruction instruction in Expression)
+            {
+                size += instruction.GetSize();
+            }
+            return size;
         }
     }
 }

--- a/Wazzy/Bytecode/Instructions/Memory/LoadF32Ins.cs
+++ b/Wazzy/Bytecode/Instructions/Memory/LoadF32Ins.cs
@@ -7,7 +7,7 @@ namespace Wazzy.Bytecode.Instructions.Memory
         public LoadF32Ins()
             : base(OPCode.LoadF32, true)
         { }
-        public LoadF32Ins(WASMReader input)
+        public LoadF32Ins(ref WASMReader input)
             : base(OPCode.LoadF32, input, true)
         { }
         public LoadF32Ins(int align, int offset)

--- a/Wazzy/Bytecode/Instructions/Memory/LoadF64Ins.cs
+++ b/Wazzy/Bytecode/Instructions/Memory/LoadF64Ins.cs
@@ -7,7 +7,7 @@ namespace Wazzy.Bytecode.Instructions.Memory
         public LoadF64Ins()
             : base(OPCode.LoadF64, true)
         { }
-        public LoadF64Ins(WASMReader input)
+        public LoadF64Ins(ref WASMReader input)
             : base(OPCode.LoadF64, input, true)
         { }
         public LoadF64Ins(int align, int offset)

--- a/Wazzy/Bytecode/Instructions/Memory/LoadI32Ins.cs
+++ b/Wazzy/Bytecode/Instructions/Memory/LoadI32Ins.cs
@@ -7,7 +7,7 @@ namespace Wazzy.Bytecode.Instructions.Memory
         public LoadI32Ins()
             : base(OPCode.LoadI32, true)
         { }
-        public LoadI32Ins(WASMReader input)
+        public LoadI32Ins(ref WASMReader input)
             : base(OPCode.LoadI32, input, true)
         { }
         public LoadI32Ins(int align, int offset)

--- a/Wazzy/Bytecode/Instructions/Memory/LoadI32_16SIns.cs
+++ b/Wazzy/Bytecode/Instructions/Memory/LoadI32_16SIns.cs
@@ -7,7 +7,7 @@ namespace Wazzy.Bytecode.Instructions.Memory
         public LoadI32_16SIns()
             : base(OPCode.LoadI32_16S, true)
         { }
-        public LoadI32_16SIns(WASMReader input)
+        public LoadI32_16SIns(ref WASMReader input)
             : base(OPCode.LoadI32_16S, input, true)
         { }
         public LoadI32_16SIns(int align, int offset)

--- a/Wazzy/Bytecode/Instructions/Memory/LoadI32_8SIns.cs
+++ b/Wazzy/Bytecode/Instructions/Memory/LoadI32_8SIns.cs
@@ -7,7 +7,7 @@ namespace Wazzy.Bytecode.Instructions.Memory
         public LoadI32_8SIns()
             : base(OPCode.LoadI32_8S, true)
         { }
-        public LoadI32_8SIns(WASMReader input)
+        public LoadI32_8SIns(ref WASMReader input)
             : base(OPCode.LoadI32_8S, input, true)
         { }
         public LoadI32_8SIns(int align, int offset)

--- a/Wazzy/Bytecode/Instructions/Memory/LoadI32_8UIns.cs
+++ b/Wazzy/Bytecode/Instructions/Memory/LoadI32_8UIns.cs
@@ -8,7 +8,7 @@ namespace Wazzy.Bytecode.Instructions.Memory
         public LoadI32_8UIns()
             : base(OPCode.LoadI32_8U, true)
         { }
-        public LoadI32_8UIns(WASMReader input)
+        public LoadI32_8UIns(ref WASMReader input)
             : base(OPCode.LoadI32_8U, input, true)
         { }
         public LoadI32_8UIns(int align, int offset)

--- a/Wazzy/Bytecode/Instructions/Memory/LoadI64Ins.cs
+++ b/Wazzy/Bytecode/Instructions/Memory/LoadI64Ins.cs
@@ -7,7 +7,7 @@ namespace Wazzy.Bytecode.Instructions.Memory
         public LoadI64Ins()
             : base(OPCode.LoadI64, true)
         { }
-        public LoadI64Ins(WASMReader input)
+        public LoadI64Ins(ref WASMReader input)
             : base(OPCode.LoadI64, input, true)
         { }
         public LoadI64Ins(int align, int offset)

--- a/Wazzy/Bytecode/Instructions/Memory/LoadI64_32UIns.cs
+++ b/Wazzy/Bytecode/Instructions/Memory/LoadI64_32UIns.cs
@@ -7,7 +7,7 @@ namespace Wazzy.Bytecode.Instructions.Memory
         public LoadI64_32UIns()
             : base(OPCode.LoadI64_32U, true)
         { }
-        public LoadI64_32UIns(WASMReader input)
+        public LoadI64_32UIns(ref WASMReader input)
             : base(OPCode.LoadI64_32U, input, true)
         { }
         public LoadI64_32UIns(int align, int offset)

--- a/Wazzy/Bytecode/Instructions/Memory/LoadI64_8SIns.cs
+++ b/Wazzy/Bytecode/Instructions/Memory/LoadI64_8SIns.cs
@@ -7,7 +7,7 @@ namespace Wazzy.Bytecode.Instructions.Memory
         public LoadI64_8SIns()
             : base(OPCode.LoadI64_8S, true)
         { }
-        public LoadI64_8SIns(WASMReader input)
+        public LoadI64_8SIns(ref WASMReader input)
             : base(OPCode.LoadI64_8S, input, true)
         { }
         public LoadI64_8SIns(int align, int offset)

--- a/Wazzy/Bytecode/Instructions/Memory/MemoryGrowIns.cs
+++ b/Wazzy/Bytecode/Instructions/Memory/MemoryGrowIns.cs
@@ -11,13 +11,15 @@ namespace Wazzy.Bytecode.Instructions.Memory
         {
             Index = index;
         }
-        public MemoryGrowIns(WASMReader input)
+        public MemoryGrowIns(ref WASMReader input)
             : this(input.ReadByte())
         { }
 
-        protected override void WriteBodyTo(WASMWriter output)
+        protected override void WriteBodyTo(ref WASMWriter output)
         {
             output.Write(Index);
         }
+
+        protected override int GetBodySize() => sizeof(byte);
     }
 }

--- a/Wazzy/Bytecode/Instructions/Memory/MemoryInstruction.cs
+++ b/Wazzy/Bytecode/Instructions/Memory/MemoryInstruction.cs
@@ -25,18 +25,24 @@ namespace Wazzy.Bytecode.Instructions.Memory
         {
             if (_hasMemoryArguments = hasMemoryArguments)
             {
-                Align = input.Read7BitEncodedInt();
-                Offset = input.Read7BitEncodedInt();
+                Align = input.ReadIntLEB128();
+                Offset = input.ReadIntLEB128();
             }
         }
 
-        protected override void WriteBodyTo(WASMWriter output)
+        protected override void WriteBodyTo(ref WASMWriter output)
         {
             if (_hasMemoryArguments)
             {
-                output.Write7BitEncodedInt(Align);
-                output.Write7BitEncodedInt(Offset);
+                output.WriteLEB128(Align);
+                output.WriteLEB128(Offset);
             }
+        }
+
+        protected override int GetBodySize()
+        {
+            return _hasMemoryArguments ? 
+                WASMReader.GetLEB128Size(Align) + WASMReader.GetLEB128Size(Offset) : 0;
         }
     }
 }

--- a/Wazzy/Bytecode/Instructions/Memory/MemorySizeIns.cs
+++ b/Wazzy/Bytecode/Instructions/Memory/MemorySizeIns.cs
@@ -11,13 +11,15 @@ namespace Wazzy.Bytecode.Instructions.Memory
         {
             Index = index;
         }
-        public MemorySizeIns(WASMReader input)
+        public MemorySizeIns(ref WASMReader input)
             : this(input.ReadByte())
         { }
 
-        protected override void WriteBodyTo(WASMWriter output)
+        protected override void WriteBodyTo(ref WASMWriter output)
         {
             output.Write(Index);
         }
+
+        protected override int GetBodySize() => sizeof(byte);
     }
 }

--- a/Wazzy/Bytecode/Instructions/Memory/StoreF32Ins.cs
+++ b/Wazzy/Bytecode/Instructions/Memory/StoreF32Ins.cs
@@ -7,7 +7,7 @@ namespace Wazzy.Bytecode.Instructions.Memory
         public StoreF32Ins()
             : base(OPCode.StoreF32, true)
         { }
-        public StoreF32Ins(WASMReader input)
+        public StoreF32Ins(ref WASMReader input)
             : base(OPCode.StoreF32, input, true)
         { }
         public StoreF32Ins(int align, int offset)

--- a/Wazzy/Bytecode/Instructions/Memory/StoreI32Ins.cs
+++ b/Wazzy/Bytecode/Instructions/Memory/StoreI32Ins.cs
@@ -4,7 +4,7 @@ namespace Wazzy.Bytecode.Instructions.Memory
 {
     public class StoreI32Ins : MemoryInstruction
     {
-        public StoreI32Ins(WASMReader input)
+        public StoreI32Ins(ref WASMReader input)
             : base(OPCode.StoreI32, input, true)
         { }
         public StoreI32Ins(int align, int offset)

--- a/Wazzy/Bytecode/Instructions/Memory/StoreI32_16Ins.cs
+++ b/Wazzy/Bytecode/Instructions/Memory/StoreI32_16Ins.cs
@@ -7,7 +7,7 @@ namespace Wazzy.Bytecode.Instructions.Memory
         public StoreI32_16Ins()
             : base(OPCode.StoreI32_16, true)
         { }
-        public StoreI32_16Ins(WASMReader input)
+        public StoreI32_16Ins(ref WASMReader input)
             : base(OPCode.StoreI32_16, input, true)
         { }
         public StoreI32_16Ins(int align, int offset)

--- a/Wazzy/Bytecode/Instructions/Memory/StoreI32_8Ins.cs
+++ b/Wazzy/Bytecode/Instructions/Memory/StoreI32_8Ins.cs
@@ -7,7 +7,7 @@ namespace Wazzy.Bytecode.Instructions.Memory
         public StoreI32_8Ins()
             : base(OPCode.StoreI32_8, true)
         { }
-        public StoreI32_8Ins(WASMReader input)
+        public StoreI32_8Ins(ref WASMReader input)
             : base(OPCode.StoreI32_8, input, true)
         { }
         public StoreI32_8Ins(int align, int offset)

--- a/Wazzy/Bytecode/Instructions/Memory/StoreI64Ins.cs
+++ b/Wazzy/Bytecode/Instructions/Memory/StoreI64Ins.cs
@@ -7,7 +7,7 @@ namespace Wazzy.Bytecode.Instructions.Memory
         public StoreI64Ins()
             : base(OPCode.StoreI64, true)
         { }
-        public StoreI64Ins(WASMReader input)
+        public StoreI64Ins(ref WASMReader input)
             : base(OPCode.StoreI64, input, true)
         { }
         public StoreI64Ins(int align, int offset)

--- a/Wazzy/Bytecode/Instructions/Numeric/ConstantF32Ins.cs
+++ b/Wazzy/Bytecode/Instructions/Numeric/ConstantF32Ins.cs
@@ -8,7 +8,7 @@ namespace Wazzy.Bytecode.Instructions.Numeric
     {
         public float Constant { get; set; }
 
-        public ConstantF32Ins(WASMReader input)
+        public ConstantF32Ins(ref WASMReader input)
             : this(input.ReadSingle())
         { }
         public ConstantF32Ins(float constant = 0)
@@ -22,9 +22,11 @@ namespace Wazzy.Bytecode.Instructions.Numeric
             stack.Push(Constant);
         }
 
-        protected override void WriteBodyTo(WASMWriter output)
+        protected override void WriteBodyTo(ref WASMWriter output)
         {
             output.Write(Constant);
         }
+
+        protected override int GetBodySize() => sizeof(float);
     }
 }

--- a/Wazzy/Bytecode/Instructions/Numeric/ConstantF64Ins.cs
+++ b/Wazzy/Bytecode/Instructions/Numeric/ConstantF64Ins.cs
@@ -8,7 +8,7 @@ namespace Wazzy.Bytecode.Instructions.Numeric
     {
         public double Constant { get; set; }
 
-        public ConstantF64Ins(WASMReader input)
+        public ConstantF64Ins(ref WASMReader input)
             : this(input.ReadDouble())
         { }
         public ConstantF64Ins(double constant = 0)
@@ -22,9 +22,11 @@ namespace Wazzy.Bytecode.Instructions.Numeric
             stack.Push(Constant);
         }
 
-        protected override void WriteBodyTo(WASMWriter output)
+        protected override void WriteBodyTo(ref WASMWriter output)
         {
             output.Write(Constant);
         }
+
+        protected override int GetBodySize() => sizeof(double);
     }
 }

--- a/Wazzy/Bytecode/Instructions/Numeric/ConstantI32Ins.cs
+++ b/Wazzy/Bytecode/Instructions/Numeric/ConstantI32Ins.cs
@@ -8,23 +8,25 @@ namespace Wazzy.Bytecode.Instructions.Numeric
     {
         public int Constant { get; set; }
 
+        public ConstantI32Ins(ref WASMReader input)
+            : this(input.ReadIntLEB128())
+        { }
         public ConstantI32Ins(int constant = 0)
             : base(OPCode.ConstantI32)
         {
             Constant = constant;
         }
-        public ConstantI32Ins(WASMReader input)
-            : this(input.Read7BitEncodedInt())
-        { }
 
         public override void Execute(Stack<object> stack, WASMModule context)
         {
             stack.Push(Constant);
         }
 
-        protected override void WriteBodyTo(WASMWriter output)
+        protected override void WriteBodyTo(ref WASMWriter output)
         {
-            output.Write7BitEncodedInt(Constant);
+            output.WriteLEB128(Constant);
         }
+
+        protected override int GetBodySize() => WASMReader.GetLEB128Size(Constant);
     }
 }

--- a/Wazzy/Bytecode/Instructions/Numeric/ConstantI64Ins.cs
+++ b/Wazzy/Bytecode/Instructions/Numeric/ConstantI64Ins.cs
@@ -6,18 +6,20 @@ namespace Wazzy.Bytecode.Instructions.Numeric
     {
         public int Constant { get; set; }
 
+        public ConstantI64Ins(ref WASMReader input)
+            : this(input.ReadIntLEB128())
+        { }
         public ConstantI64Ins(int constant = 0)
             : base(OPCode.ConstantI64)
         {
             Constant = constant;
         }
-        public ConstantI64Ins(WASMReader input)
-            : this(input.Read7BitEncodedInt())
-        { }
 
-        protected override void WriteBodyTo(WASMWriter output)
+        protected override void WriteBodyTo(ref WASMWriter output)
         {
-            output.Write7BitEncodedInt(Constant);
+            output.WriteLEB128(Constant);
         }
+
+        protected override int GetBodySize() => WASMReader.GetLEB128Size(Constant);
     }
 }

--- a/Wazzy/Bytecode/Instructions/Variable/GetGlobalIns.cs
+++ b/Wazzy/Bytecode/Instructions/Variable/GetGlobalIns.cs
@@ -13,8 +13,8 @@ namespace Wazzy.Bytecode.Instructions.Variable
         {
             Id = id;
         }
-        public GetGlobalIns(WASMReader input)
-            : this(input.Read7BitEncodedInt())
+        public GetGlobalIns(ref WASMReader input)
+            : this(input.ReadIntLEB128())
         { }
 
         public override void Execute(Stack<object> stack, WASMModule context)
@@ -22,9 +22,11 @@ namespace Wazzy.Bytecode.Instructions.Variable
             WASMMachine.Execute(context.GlobalSec[Id].Expression, context, stack);
         }
 
-        protected override void WriteBodyTo(WASMWriter output)
+        protected override void WriteBodyTo(ref WASMWriter output)
         {
-            output.Write7BitEncodedInt(Id);
+            output.WriteLEB128(Id);
         }
+
+        protected override int GetBodySize() => WASMReader.GetLEB128Size(Id);
     }
 }

--- a/Wazzy/Bytecode/Instructions/Variable/GetLocalIns.cs
+++ b/Wazzy/Bytecode/Instructions/Variable/GetLocalIns.cs
@@ -11,13 +11,15 @@ namespace Wazzy.Bytecode.Instructions.Variable
         {
             Id = id;
         }
-        public GetLocalIns(WASMReader input)
-            : this(input.Read7BitEncodedInt())
+        public GetLocalIns(ref WASMReader input)
+            : this(input.ReadIntLEB128())
         { }
 
-        protected override void WriteBodyTo(WASMWriter output)
+        protected override void WriteBodyTo(ref WASMWriter output)
         {
-            output.Write7BitEncodedInt(Id);
+            output.WriteLEB128(Id);
         }
+
+        protected override int GetBodySize() => WASMReader.GetLEB128Size(Id);
     }
 }

--- a/Wazzy/Bytecode/Instructions/Variable/SetGlobalIns.cs
+++ b/Wazzy/Bytecode/Instructions/Variable/SetGlobalIns.cs
@@ -11,13 +11,15 @@ namespace Wazzy.Bytecode.Instructions.Variable
         {
             Id = id;
         }
-        public SetGlobalIns(WASMReader input)
-            : this(input.Read7BitEncodedInt())
+        public SetGlobalIns(ref WASMReader input)
+            : this(input.ReadIntLEB128())
         { }
 
-        protected override void WriteBodyTo(WASMWriter output)
+        protected override void WriteBodyTo(ref WASMWriter output)
         {
-            output.Write7BitEncodedInt(Id);
+            output.WriteLEB128(Id);
         }
+
+        protected override int GetBodySize() => WASMReader.GetLEB128Size(Id);
     }
 }

--- a/Wazzy/Bytecode/Instructions/Variable/SetLocalIns.cs
+++ b/Wazzy/Bytecode/Instructions/Variable/SetLocalIns.cs
@@ -11,13 +11,15 @@ namespace Wazzy.Bytecode.Instructions.Variable
         {
             Id = id;
         }
-        public SetLocalIns(WASMReader input)
-            : this(input.Read7BitEncodedInt())
+        public SetLocalIns(ref WASMReader input)
+            : this(input.ReadIntLEB128())
         { }
 
-        protected override void WriteBodyTo(WASMWriter output)
+        protected override void WriteBodyTo(ref WASMWriter output)
         {
-            output.Write7BitEncodedInt(Id);
+            output.WriteLEB128(Id);
         }
+
+        protected override int GetBodySize() => WASMReader.GetLEB128Size(Id);
     }
 }

--- a/Wazzy/Bytecode/Instructions/Variable/TeeLocalIns.cs
+++ b/Wazzy/Bytecode/Instructions/Variable/TeeLocalIns.cs
@@ -11,13 +11,15 @@ namespace Wazzy.Bytecode.Instructions.Variable
         {
             Id = id;
         }
-        public TeeLocalIns(WASMReader input)
-            : this(input.Read7BitEncodedInt())
+        public TeeLocalIns(ref WASMReader input)
+            : this(input.ReadIntLEB128())
         { }
 
-        protected override void WriteBodyTo(WASMWriter output)
+        protected override void WriteBodyTo(ref WASMWriter output)
         {
-            output.Write7BitEncodedInt(Id);
+            output.WriteLEB128(Id);
         }
+
+        protected override int GetBodySize() => WASMReader.GetLEB128Size(Id);
     }
 }

--- a/Wazzy/Bytecode/WASMInstruction.cs
+++ b/Wazzy/Bytecode/WASMInstruction.cs
@@ -23,29 +23,42 @@ namespace Wazzy.Bytecode
         public virtual void Execute(Stack<object> stack, WASMModule context)
         { }
 
-        public override void WriteTo(WASMWriter output)
+        public override int GetSize()
+        {
+            int size = 0;
+            size += sizeof(byte);
+            size += GetBodySize();
+            return size;
+        }
+        protected virtual int GetBodySize()
+        {
+            return 0;
+        }
+
+        public override void WriteTo(ref WASMWriter output)
         {
             output.Write((byte)OP);
-            WriteBodyTo(output);
+            WriteBodyTo(ref output);
         }
-        protected virtual void WriteBodyTo(WASMWriter output)
+        protected virtual void WriteBodyTo(ref WASMWriter output)
         { }
 
-        public static WASMInstruction Create(OPCode op, WASMReader input = null) => op switch
+        public static WASMInstruction Create(ref WASMReader input) => Create((OPCode)input.ReadByte(), ref input);
+        public static WASMInstruction Create(OPCode op, ref WASMReader input) => op switch
         {
             // Control
             OPCode.Unreachable => new UnreachableIns(),
             OPCode.Nop => new NopIns(),
-            OPCode.Block => new BlockIns(input),
-            OPCode.Loop => new LoopIns(input),
-            OPCode.If => new IfIns(input),
-            OPCode.Branch => new BranchIns(input),
-            OPCode.BranchIf => new BranchIfIns(input),
-            OPCode.BranchTable => new BranchTableIns(input),
+            OPCode.Block => new BlockIns(ref input),
+            OPCode.Loop => new LoopIns(ref input),
+            OPCode.If => new IfIns(ref input),
+            OPCode.Branch => new BranchIns(ref input),
+            OPCode.BranchIf => new BranchIfIns(ref input),
+            OPCode.BranchTable => new BranchTableIns(ref input),
             OPCode.Else => new ElseIns(),
             OPCode.Return => new ReturnIns(),
-            OPCode.Call => new CallIns(input),
-            OPCode.CallIndirect => new CallIndirectIns(input),
+            OPCode.Call => new CallIns(ref input),
+            OPCode.CallIndirect => new CallIndirectIns(ref input),
             OPCode.End => new EndIns(),
 
             // Parametric
@@ -53,10 +66,10 @@ namespace Wazzy.Bytecode
             OPCode.Select => new SelectIns(),
 
             // Numeric
-            OPCode.ConstantI32 => new ConstantI32Ins(input),
-            OPCode.ConstantI64 => new ConstantI64Ins(input),
-            OPCode.ConstantF32 => new ConstantF32Ins(input),
-            OPCode.ConstantF64 => new ConstantF64Ins(input),
+            OPCode.ConstantI32 => new ConstantI32Ins(ref input),
+            OPCode.ConstantI64 => new ConstantI64Ins(ref input),
+            OPCode.ConstantF32 => new ConstantF32Ins(ref input),
+            OPCode.ConstantF64 => new ConstantF64Ins(ref input),
             OPCode.EqualZeroI32 => new EqualZeroI32Ins(),
             OPCode.EqualI32 => new EqualI32Ins(),
             OPCode.AddI32 => new AddI32Ins(),
@@ -127,32 +140,31 @@ namespace Wazzy.Bytecode
             OPCode.NegateF32 => new NegateF32Ins(),
 
             // Variable
-            OPCode.GetLocal => new GetLocalIns(input),
-            OPCode.SetLocal => new SetLocalIns(input),
-            OPCode.TeeLocal => new TeeLocalIns(input),
-            OPCode.GetGlobal => new GetGlobalIns(input),
-            OPCode.SetGlobal => new SetGlobalIns(input),
+            OPCode.GetLocal => new GetLocalIns(ref input),
+            OPCode.SetLocal => new SetLocalIns(ref input),
+            OPCode.TeeLocal => new TeeLocalIns(ref input),
+            OPCode.GetGlobal => new GetGlobalIns(ref input),
+            OPCode.SetGlobal => new SetGlobalIns(ref input),
 
             // Memory
-            OPCode.LoadI32 => new LoadI32Ins(input),
-            OPCode.LoadI64 => new LoadI64Ins(input),
-            OPCode.LoadI64_8S => new LoadI64_8SIns(input),
-            OPCode.LoadI64_32U => new LoadI64_32UIns(input),
-            OPCode.LoadF32 => new LoadF32Ins(input),
-            OPCode.LoadI32_8S => new LoadI32_8SIns(input),
-            OPCode.LoadI32_8U => new LoadI32_8UIns(input),
-            OPCode.LoadF64 => new LoadF64Ins(input),
-            OPCode.StoreI32 => new StoreI32Ins(input),
-            OPCode.StoreI32_8 => new StoreI32_8Ins(input),
-            OPCode.StoreI32_16=> new StoreI32_16Ins(input),
-            OPCode.LoadI32_16S => new LoadI32_16SIns(input),
-            OPCode.StoreI64 => new StoreI64Ins(input),
-            OPCode.StoreF32 => new StoreF32Ins(input),
-            OPCode.MemoryGrow => new MemoryGrowIns(input),
-            OPCode.MemorySize => new MemorySizeIns(input),
+            OPCode.LoadI32 => new LoadI32Ins(ref input),
+            OPCode.LoadI64 => new LoadI64Ins(ref input),
+            OPCode.LoadI64_8S => new LoadI64_8SIns(ref input),
+            OPCode.LoadI64_32U => new LoadI64_32UIns(ref input),
+            OPCode.LoadF32 => new LoadF32Ins(ref input),
+            OPCode.LoadI32_8S => new LoadI32_8SIns(ref input),
+            OPCode.LoadI32_8U => new LoadI32_8UIns(ref input),
+            OPCode.LoadF64 => new LoadF64Ins(ref input),
+            OPCode.StoreI32 => new StoreI32Ins(ref input),
+            OPCode.StoreI32_8 => new StoreI32_8Ins(ref input),
+            OPCode.StoreI32_16=> new StoreI32_16Ins(ref input),
+            OPCode.LoadI32_16S => new LoadI32_16SIns(ref input),
+            OPCode.StoreI64 => new StoreI64Ins(ref input),
+            OPCode.StoreF32 => new StoreF32Ins(ref input),
+            OPCode.MemoryGrow => new MemoryGrowIns(ref input),
+            OPCode.MemorySize => new MemorySizeIns(ref input),
 
             _ => throw new NotImplementedException($"This instruction has not yet been implemented or does not exist in the specification. {op}(0x{(byte)op:X2})")
         };
-        public static WASMInstruction Create(WASMReader input) => Create((OPCode)input.ReadByte(), input);
     }
 }

--- a/Wazzy/IO/WASMObject.cs
+++ b/Wazzy/IO/WASMObject.cs
@@ -1,25 +1,19 @@
-﻿using System.IO;
-using System.Collections.Generic;
+﻿using System.Buffers;
 
 namespace Wazzy.IO
 {
     public abstract class WASMObject
     {
-        public abstract void WriteTo(WASMWriter output);
-
-        public static byte[] ToBytes<T>(IList<T> wasmObjs) where T : WASMObject
+        public void WriteTo(IBufferWriter<byte> output)
         {
-            if (wasmObjs.Count == 0) return new byte[0];
+            int size = GetSize();
+            var writer = new WASMWriter(output.GetSpan(size));
 
-            using var output = new MemoryStream();
-            using var wasmOutput = new WASMWriter(output);
-            foreach (WASMObject wasmObj in wasmObjs)
-            {
-                wasmObj.WriteTo(wasmOutput);
-            }
-            wasmOutput.Flush();
-            return output.ToArray();
+            WriteTo(ref writer);
+            output.Advance(size);
         }
-        public static byte[] ToBytes(WASMObject wasmObj) => ToBytes(new[] { wasmObj }); // Whatever, don't @ me
+
+        public abstract int GetSize();
+        public abstract void WriteTo(ref WASMWriter output);
     }
 }

--- a/Wazzy/Sections/ElementSection.cs
+++ b/Wazzy/Sections/ElementSection.cs
@@ -5,22 +5,33 @@ namespace Wazzy.Sections
 {
     public class ElementSection : WASMSectionEnumerable<ElementSubsection>
     {
-        public ElementSection(WASMModule module)
-            : base(module, WASMSectionId.ElementSection)
+        public ElementSection(WASMModule module, ref WASMReader input)
+            : base(WASMSectionId.ElementSection)
         {
-            Subsections.Capacity = module.Input.Read7BitEncodedInt();
+            Subsections.Capacity = input.ReadIntLEB128();
             for (int i = 0; i < Subsections.Capacity; i++)
             {
-                Add(new ElementSubsection(module));
+                Add(new ElementSubsection(module, ref input));
             }
         }
 
-        protected override void WriteBodyTo(WASMWriter output, int globalPosition)
+        protected override int GetBodySize()
         {
-            output.Write7BitEncodedInt(Subsections.Count);
+            int size = 0;
+            size += WASMReader.GetLEB128Size(Subsections.Count);
             foreach (ElementSubsection element in Subsections)
             {
-                element.WriteTo(output);
+                size += element.GetSize();
+            }
+            return size;
+        }
+
+        protected override void WriteBodyTo(ref WASMWriter output)
+        {
+            output.WriteLEB128(Subsections.Count);
+            foreach (ElementSubsection element in Subsections)
+            {
+                element.WriteTo(ref output);
             }
         }
     }

--- a/Wazzy/Sections/ExportSection.cs
+++ b/Wazzy/Sections/ExportSection.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 
 using Wazzy.IO;
 
@@ -10,31 +11,47 @@ namespace Wazzy.Sections
         public byte[] Tags { get; }
         public int[] Indices { get; }
 
-        public ExportSection(WASMModule module)
-            : base(module, WASMSectionId.ExportSection)
+        public ExportSection(ref WASMReader input)
+            : base(WASMSectionId.ExportSection)
         {
-            int exportCount = module.Input.Read7BitEncodedInt();
+            int exportCount = input.ReadIntLEB128();
             Names = new string[exportCount];
             Tags = new byte[exportCount];
             Indices = new int[exportCount];
 
             for (int i = 0; i < exportCount; i++)
             {
-                Names[i] = module.Input.Read7BitEncodedString();
-                Tags[i] = module.Input.ReadByte();
-                Indices[i] = module.Input.Read7BitEncodedInt();
+                Names[i] = input.ReadString();
+                Tags[i] = input.ReadByte();
+                Indices[i] = input.ReadIntLEB128();
             }
         }
 
-        protected override void WriteBodyTo(WASMWriter output, int globalPosition)
+        protected override int GetBodySize()
         {
             int exportCount = Math.Min(Names.Length, Math.Min(Tags.Length, Indices.Length));
-            output.Write7BitEncodedInt(exportCount);
+
+            int size = 0;
+            size += WASMReader.GetLEB128Size(exportCount);
             for (int i = 0; i < exportCount; i++)
             {
-                output.Write7BitEncodedString(Names[i]);
+                size += WASMReader.GetULEB128Size((uint)Names[i].Length);
+                size += Encoding.UTF8.GetByteCount(Names[i]);
+                size += sizeof(byte);
+                size += WASMReader.GetLEB128Size(Indices[i]);
+            }
+            return size;
+        }
+
+        protected override void WriteBodyTo(ref WASMWriter output)
+        {
+            int exportCount = Math.Min(Names.Length, Math.Min(Tags.Length, Indices.Length));
+            output.WriteLEB128(exportCount);
+            for (int i = 0; i < exportCount; i++)
+            {
+                output.WriteString(Names[i]);
                 output.Write(Tags[i]);
-                output.Write7BitEncodedInt(Indices[i]);
+                output.WriteLEB128(Indices[i]);
             }
         }
     }

--- a/Wazzy/Sections/FunctionSection.cs
+++ b/Wazzy/Sections/FunctionSection.cs
@@ -4,22 +4,33 @@ namespace Wazzy.Sections
 {
     public class FunctionSection : WASMSectionEnumerable<int>
     {
-        public FunctionSection(WASMModule module)
-            : base(module, WASMSectionId.FunctionSection)
+        public FunctionSection(ref WASMReader input)
+            : base(WASMSectionId.FunctionSection)
         {
-            Subsections.Capacity = module.Input.Read7BitEncodedInt();
+            Subsections.Capacity = input.ReadIntLEB128();
             for (int i = 0; i < Subsections.Capacity; i++)
             {
-                Subsections.Add(module.Input.Read7BitEncodedInt());
+                Subsections.Add(input.ReadIntLEB128());
             }
         }
 
-        protected override void WriteBodyTo(WASMWriter output, int globalPosition)
+        protected override int GetBodySize()
         {
-            output.Write7BitEncodedInt(Subsections.Count);
+            int size = 0;
+            size += WASMReader.GetLEB128Size(Subsections.Count);
             foreach (int typeIndex in Subsections)
             {
-                output.Write7BitEncodedInt(typeIndex);
+                size += WASMReader.GetLEB128Size(typeIndex);
+            }
+            return size;
+        }
+
+        protected override void WriteBodyTo(ref WASMWriter output)
+        {
+            output.WriteLEB128(Subsections.Count);
+            foreach (int typeIndex in Subsections)
+            {
+                output.WriteLEB128(typeIndex);
             }
         }
     }

--- a/Wazzy/Sections/ImportSection.cs
+++ b/Wazzy/Sections/ImportSection.cs
@@ -5,22 +5,33 @@ namespace Wazzy.Sections
 {
     public class ImportSection : WASMSectionEnumerable<ImportSubsection>
     {
-        public ImportSection(WASMModule module)
-            : base(module, WASMSectionId.ImportSection)
+        public ImportSection(ref WASMReader input)
+            : base(WASMSectionId.ImportSection)
         {
-            Subsections.Capacity = module.Input.Read7BitEncodedInt();
+            Subsections.Capacity = input.ReadIntLEB128();
             for (int i = 0; i < Subsections.Capacity; i++)
             {
-                Add(new ImportSubsection(module));
+                Add(new ImportSubsection(ref input));
             }
         }
 
-        protected override void WriteBodyTo(WASMWriter output, int globalPosition)
+        protected override int GetBodySize()
         {
-            output.Write7BitEncodedInt(Subsections.Count);
+            int size = 0;
+            size += WASMReader.GetLEB128Size(Subsections.Count);
             foreach (ImportSubsection import in Subsections)
             {
-                import.WriteTo(output);
+                size += import.GetSize();
+            }
+            return size;
+        }
+
+        protected override void WriteBodyTo(ref WASMWriter output)
+        {
+            output.WriteLEB128(Subsections.Count);
+            foreach (ImportSubsection import in Subsections)
+            {
+                import.WriteTo(ref output);
             }
         }
     }

--- a/Wazzy/Sections/StartSection.cs
+++ b/Wazzy/Sections/StartSection.cs
@@ -6,15 +6,20 @@ namespace Wazzy.Sections
     {
         public int FunctionId { get; set; }
 
-        public StartSection(WASMModule module)
-            : base(module, WASMSectionId.StartSection)
+        public StartSection(ref WASMReader input)
+            : base(WASMSectionId.StartSection)
         {
-            FunctionId = module.Input.Read7BitEncodedInt();
+            FunctionId = input.ReadIntLEB128();
         }
 
-        protected override void WriteBodyTo(WASMWriter output, int globalPosition)
+        protected override int GetBodySize()
         {
-            output.Write7BitEncodedInt(FunctionId);
+            return WASMReader.GetLEB128Size(FunctionId);
+        }
+
+        protected override void WriteBodyTo(ref WASMWriter output)
+        {
+            output.WriteLEB128(FunctionId);
         }
     }
 }

--- a/Wazzy/Sections/Subsections/CodeSubsection.cs
+++ b/Wazzy/Sections/Subsections/CodeSubsection.cs
@@ -14,47 +14,69 @@ namespace Wazzy.Sections.Subsections
         public List<Local> Locals { get; }
         public List<WASMInstruction> Expression { get; }
 
-        public CodeSubsection(WASMModule module)
+        public CodeSubsection(ref WASMReader input)
         {
-            int sizeOfSubsection = module.Input.Read7BitEncodedInt();
-
+            uint funcSize = input.ReadIntULEB128();
         DataStart: // Are you judging me right now? 
-            int startOfSubsection = module.Input.Position;
-            Locals = new List<Local>(module.Input.Read7BitEncodedInt());
+            int startOfSubsection = input.Position;
+            int start = input.Position;
+            Locals = new List<Local>(input.ReadIntLEB128());
             for (int i = 0; i < Locals.Capacity; i++)
             {
-                Locals.Add(new Local(module));
+                Locals.Add(new Local(ref input));
             }
 
-            int startOfBytecode = module.Input.Position;
-            int sizeOfBytecode = sizeOfSubsection - (startOfBytecode - startOfSubsection);
+            int startOfBytecode = input.Position;
+            int sizeOfBytecode = (int)funcSize - (startOfBytecode - startOfSubsection);
 
 #if Peanut_Debugging
-            Expression = module.Input.ReadExpression();
+            Expression = input.ReadExpression();
 #else
-            Body = module.Input.ReadBytes(sizeOfBytecode);
+            Body = input.ReadBytes(sizeOfBytecode).ToArray();
 #endif
 #if Peanut_Debugging
-            int bytesRead = module.Input.Position - startOfBytecode;
+            int bytesRead = input.Position - startOfBytecode;
             if (bytesRead != sizeOfBytecode)
             {
                 System.Diagnostics.Debugger.Break();
-                module.Input.Position = startOfSubsection;
+                input.Position = startOfSubsection;
                 goto DataStart; // Abort Abort
             }
 #endif
         }
 
-        public override void WriteTo(WASMWriter output)
+        public override void WriteTo(ref WASMWriter output)
         {
-            int size = WASMReader.Get7BitEncodedIntSize(Locals.Count) + Body.Length;
-            byte[] localsData = ToBytes(Locals);
-            size += localsData.Length;
+            int funcSize = 0;
+            funcSize += WASMReader.GetLEB128Size(Locals.Count);
+            foreach (Local local in Locals)
+            {
+                funcSize += local.GetSize();
+            }
+            funcSize += Body.Length;
 
-            output.Write7BitEncodedInt(size);
-            output.Write7BitEncodedInt(Locals.Count);
-            output.Write(localsData);
+            output.WriteULEB128((uint)funcSize);
+            output.WriteLEB128(Locals.Count);
+            foreach (Local local in Locals)
+            {
+                local.WriteTo(ref output);
+            }
             output.Write(Body);
+        }
+
+        public override int GetSize()
+        {
+            int size = 0;
+            size += WASMReader.GetLEB128Size(Locals.Count);
+            foreach (Local local in Locals)
+            {
+                size += local.GetSize();
+            }
+            size += Body.Length;
+
+            // Finally calculate the real size
+            size += WASMReader.GetULEB128Size((uint)size);
+            return size;
         }
     }
 }

--- a/Wazzy/Sections/Subsections/GlobalSubsection.cs
+++ b/Wazzy/Sections/Subsections/GlobalSubsection.cs
@@ -11,19 +11,30 @@ namespace Wazzy.Sections.Subsections
         public GlobalType Info { get; set; }
         public List<WASMInstruction> Expression { get; set; }
 
-        public GlobalSubsection(WASMModule module)
+        public GlobalSubsection(ref WASMReader input)
         {
-            Info = new GlobalType(module);
-            Expression = module.Input.ReadExpression();
+            Info = new GlobalType(ref input);
+            Expression = input.ReadExpression();
         }
 
-        public override void WriteTo(WASMWriter output)
+        public override void WriteTo(ref WASMWriter output)
         {
-            Info.WriteTo(output);
+            Info.WriteTo(ref output);
             foreach (WASMInstruction instruction in Expression)
             {
-                instruction.WriteTo(output);
+                instruction.WriteTo(ref output);
             }
+        }
+
+        public override int GetSize()
+        {
+            int size = 0;
+            size += Info.GetSize();
+            foreach (WASMInstruction instruction in Expression)
+            {
+                size += instruction.GetSize();
+            }
+            return size;
         }
     }
 }

--- a/Wazzy/Sections/TableSection.cs
+++ b/Wazzy/Sections/TableSection.cs
@@ -5,22 +5,33 @@ namespace Wazzy.Sections
 {
     public class TableSection : WASMSectionEnumerable<TableType>
     {
-        public TableSection(WASMModule module)
-            : base(module, WASMSectionId.TableSection)
+        public TableSection(ref WASMReader input)
+            : base(WASMSectionId.TableSection)
         {
-            Subsections.Capacity = module.Input.Read7BitEncodedInt();
+            Subsections.Capacity = input.ReadIntLEB128();
             for (int i = 0; i < Subsections.Capacity; i++)
             {
-                Add(new TableType(module));
+                Add(new TableType(ref input));
             }
         }
 
-        protected override void WriteBodyTo(WASMWriter output, int globalPosition)
+        protected override int GetBodySize()
         {
-            output.Write7BitEncodedInt(Subsections.Count);
+            int size = 0;
+            size += WASMReader.GetLEB128Size(Subsections.Count);
             foreach (TableType table in Subsections)
             {
-                table.WriteTo(output);
+                size += table.GetSize();
+            }
+            return size;
+        }
+
+        protected override void WriteBodyTo(ref WASMWriter output)
+        {
+            output.WriteLEB128(Subsections.Count);
+            foreach (TableType table in Subsections)
+            {
+                table.WriteTo(ref output);
             }
         }
     }

--- a/Wazzy/Sections/WASMSectionEnumerable.cs
+++ b/Wazzy/Sections/WASMSectionEnumerable.cs
@@ -7,8 +7,8 @@ namespace Wazzy.Sections
     {
         protected List<T> Subsections { get; }
 
-        protected WASMSectionEnumerable(WASMModule module, WASMSectionId id)
-            : base(module, id)
+        protected WASMSectionEnumerable(WASMSectionId id)
+            : base(id)
         {
             Subsections = new List<T>();
         }

--- a/Wazzy/Types/FuncType.cs
+++ b/Wazzy/Types/FuncType.cs
@@ -34,36 +34,47 @@ namespace Wazzy.Types
         public List<Type> ResultTypes { get; }
         public List<Type> ParameterTypes { get; }
 
-        public FuncType(WASMModule module)
+        public FuncType(ref WASMReader input)
         {
-            ParameterTypes = new List<Type>(module.Input.Read7BitEncodedInt());
+            ParameterTypes = new List<Type>(input.ReadIntLEB128());
             for (int i = 0; i < ParameterTypes.Capacity; i++)
             {
-                Type paramType = module.Input.ReadValueType();
+                Type paramType = input.ReadValueType();
                 ParameterTypes.Add(paramType);
             }
 
-            ResultTypes = new List<Type>(module.Input.Read7BitEncodedInt());
+            ResultTypes = new List<Type>(input.ReadIntLEB128());
             for (int i = 0; i < ResultTypes.Capacity; i++)
             {
-                Type resultType = module.Input.ReadValueType();
+                Type resultType = input.ReadValueType();
                 ResultTypes.Add(resultType);
             }
         }
 
-        public override void WriteTo(WASMWriter output)
+        public override void WriteTo(ref WASMWriter output)
         {
-            output.Write7BitEncodedInt(ParameterTypes.Count);
+            output.WriteLEB128(ParameterTypes.Count);
             foreach (Type parameterType in ParameterTypes)
             {
                 output.Write(parameterType);
             }
 
-            output.Write7BitEncodedInt(ResultTypes.Count);
+            output.WriteLEB128(ResultTypes.Count);
             foreach (Type resultType in ResultTypes)
             {
                 output.Write(resultType);
             }
+        }
+
+        public override int GetSize()
+        {
+            int size = 0;
+            size += WASMReader.GetLEB128Size(ParameterTypes.Count);
+            size += ParameterTypes.Count * sizeof(byte);
+
+            size += WASMReader.GetLEB128Size(ResultTypes.Count);
+            size += ResultTypes.Count * sizeof(byte);
+            return size;
         }
     }
 }

--- a/Wazzy/Types/GlobalType.cs
+++ b/Wazzy/Types/GlobalType.cs
@@ -9,16 +9,24 @@ namespace Wazzy.Types
         public Type ValueType { get; set; }
         public bool IsReadOnly { get; set; }
 
-        public GlobalType(WASMModule module)
+        public GlobalType(ref WASMReader input)
         {
-            ValueType = module.Input.ReadValueType();
-            IsReadOnly = !module.Input.ReadBoolean();
+            ValueType = input.ReadValueType();
+            IsReadOnly = !input.ReadBoolean();
         }
 
-        public override void WriteTo(WASMWriter output)
+        public override void WriteTo(ref WASMWriter output)
         {
             output.Write(ValueType);
             output.Write(!IsReadOnly); // False|0x00 = const
+        }
+
+        public override int GetSize()
+        {
+            int size = 0;
+            size += sizeof(byte);
+            size += sizeof(byte);
+            return size;
         }
     }
 }

--- a/Wazzy/Types/Local.cs
+++ b/Wazzy/Types/Local.cs
@@ -11,20 +11,28 @@ namespace Wazzy.Types
         public int Rank { get; }
         public Type Type { get; }
 
-        public Local(WASMModule module)
+        public Local(ref WASMReader input)
         {
-            Rank = module.Input.Read7BitEncodedInt();
-            _typeIndex = module.Input.Read7BitEncodedInt();
+            Rank = input.ReadIntLEB128();
+            _typeIndex = input.ReadIntLEB128();
             if (IsSupportedType(_typeIndex))
             {
                 Type = GetType(_typeIndex);
             }
         }
 
-        public override void WriteTo(WASMWriter output)
+        public override void WriteTo(ref WASMWriter output)
         {
-            output.Write7BitEncodedInt(Rank);
-            output.Write7BitEncodedInt(_typeIndex);
+            output.WriteLEB128(Rank);
+            output.WriteLEB128(_typeIndex);
+        }
+
+        public override int GetSize()
+        {
+            int size = 0;
+            size += WASMReader.GetLEB128Size(Rank);
+            size += WASMReader.GetLEB128Size(_typeIndex);
+            return size;
         }
     }
 }

--- a/Wazzy/Types/MemoryType.cs
+++ b/Wazzy/Types/MemoryType.cs
@@ -1,9 +1,11 @@
-﻿namespace Wazzy.Types
+﻿using Wazzy.IO;
+
+namespace Wazzy.Types
 {
     public class MemoryType : Limits // All memory types are limits, but not all limits are memory types.
     {
-        public MemoryType(WASMModule module)
-            : base(module)
+        public MemoryType(ref WASMReader input)
+            : base(ref input)
         { }
     }
 }

--- a/Wazzy/Types/TableType.cs
+++ b/Wazzy/Types/TableType.cs
@@ -7,16 +7,24 @@ namespace Wazzy.Types
         public byte ElementType { get; set; } 
         public Limits Limits { get; set; }
 
-        public TableType(WASMModule module)
+        public TableType(ref WASMReader input)
         {
-            ElementType = module.Input.ReadByte(); // WASM v1 only supports funcref(0x70), but will perhaps support more in the future.
-            Limits = new Limits(module);
+            ElementType = input.ReadByte(); // WASM v1 only supports funcref(0x70), but will perhaps support more in the future.
+            Limits = new Limits(ref input);
         }
 
-        public override void WriteTo(WASMWriter output)
+        public override void WriteTo(ref WASMWriter output)
         {
             output.Write(ElementType);
-            Limits.WriteTo(output);
+            Limits.WriteTo(ref output);
+        }
+
+        public override int GetSize()
+        {
+            int size = 0;
+            size += sizeof(byte);
+            size += Limits.GetSize();
+            return size;
         }
     }
 }


### PR DESCRIPTION
Binary format reading and writing changed from the .NET built-in BinaryReader & streams to lightweight (ReadOnly)Span<T> backed custom built ref structs. This change heavily constraints the usage of the `WASMReader` and `WASMWriter` as a trade-off for better performance.
Right now it requires the entire WASM module to be loaded into memory at once but I have plans to support reading from streams of data by making use of the System.IO.Pipelines NuGet package 😃 